### PR TITLE
Handle nested multipart messages

### DIFF
--- a/src/Network/Mail/Parse/Parsers/Message.hs
+++ b/src/Network/Mail/Parse/Parsers/Message.hs
@@ -61,11 +61,7 @@ messageParser headersIn helperHeadersIn = do
 
   body <- takeByteString
   let parsedHeaders = map parseHeader headers
-
-  -- Parse MIME if the message is in a MIME format
-  let parsedBody = if isJust $ find isMIME headers
-      then parseMIME (headers ++ helperHeaders) body
-      else Right [TextBody $ decodeTextBody (headers ++ helperHeaders) body]
+      parsedBody = parseMIME (headers ++ helperHeaders) body
 
   return $! parsedBody >>= return . EmailMessage parsedHeaders
 


### PR DESCRIPTION
Currently nested multipart messages such as `[[text, html], attachment]` are not handled properly, as the inner multipart is treated as raw text and smashed together with the boundaries still left in.

In practice this does happen quite frequently, a sizable portion of my gmail inbox falls under this category.

Since `parseMime` already seems to gracefully handle non-MIME data via looking at the `Content-Type` header, I simply deleted the `isMime` check and unconditionally called `parseMime`.